### PR TITLE
Replace deprecated endpoint

### DIFF
--- a/python/push-to-loki.py
+++ b/python/push-to-loki.py
@@ -10,7 +10,7 @@ curr_datetime = curr_datetime.isoformat('T')
 msg = 'On server {host} detected error'.format(host=host)
 
 # push msg log into grafana-loki
-url = 'http://host-where-loki-run:3100/api/prom/push'
+url = 'http://host-where-loki-run:3100/loki/api/v1/push '
 headers = {
     'Content-type': 'application/json'
 }


### PR DESCRIPTION
the /api/prom/push endpoint is deprecated. The new endpoint path is /loki/api/v1/push according to https://grafana.com/docs/loki/latest/reference/api/#post-apiprompush